### PR TITLE
Missing boolean type in arrayMerge option

### DIFF
--- a/lib/merge.d.ts
+++ b/lib/merge.d.ts
@@ -20,7 +20,7 @@ declare namespace merge {
         combine?: boolean;
         descriptor?: boolean;
         filter?: FilterCallback;
-        arrayMerge?: ArrayMergeCallback
+        arrayMerge?: boolean|ArrayMergeCallback
 
     }
 


### PR DESCRIPTION
I found out that the "boolean" was missing from the arrayMerge option, because of which, I wasn't able to set the option as true.